### PR TITLE
uri encode the to path

### DIFF
--- a/lib/middleman-s3_redirect/extension.rb
+++ b/lib/middleman-s3_redirect/extension.rb
@@ -51,7 +51,7 @@ module Middleman
         attr_reader :from, :to
         def initialize(from, to)
           @from = normalize(from)
-          @to = URI.encode(to)
+          @to = URI.encode(to).gsub('%23', '#')
         end
 
         protected

--- a/lib/middleman-s3_redirect/extension.rb
+++ b/lib/middleman-s3_redirect/extension.rb
@@ -51,7 +51,7 @@ module Middleman
         attr_reader :from, :to
         def initialize(from, to)
           @from = normalize(from)
-          @to = to
+          @to = URI.encode(to)
         end
 
         protected


### PR DESCRIPTION
This allows non-ascii target paths - such as Japanese or Korean.
